### PR TITLE
Add weeknotes helper command

### DIFF
--- a/config/nvim/lua/weeknotes/init.lua
+++ b/config/nvim/lua/weeknotes/init.lua
@@ -1,0 +1,9 @@
+local refs = require("weeknotes.refs")
+local transform = require("weeknotes.transform")
+
+local M = {}
+
+M.transform_range = transform.transform_range
+M.rebuild_refs = refs.rebuild_refs
+
+return M

--- a/config/nvim/lua/weeknotes/refs.lua
+++ b/config/nvim/lua/weeknotes/refs.lua
@@ -1,0 +1,89 @@
+local text = require("weeknotes.text")
+
+local M = {}
+
+local function push_unique(list, seen, value)
+  if seen[value] then
+    return
+  end
+
+  seen[value] = true
+  table.insert(list, value)
+end
+
+local function sorted_labels(defs)
+  local labels = {}
+  for label, _ in pairs(defs) do
+    table.insert(labels, label)
+  end
+
+  text.sort_labels(labels)
+  return labels
+end
+
+local function labels_in_body(body_lines, defs)
+  local labels = {}
+  local seen = {}
+
+  for _, line in ipairs(body_lines) do
+    for label in line:gmatch("%[([^%]]+)%]") do
+      if defs[label] then
+        push_unique(labels, seen, label)
+      end
+    end
+  end
+
+  return labels
+end
+
+function M.append_definitions(output, defs, label_order)
+  local labels = label_order or sorted_labels(defs)
+  if #labels == 0 then
+    return
+  end
+
+  table.insert(output, "")
+  for _, label in ipairs(labels) do
+    table.insert(output, "[" .. label .. "]: " .. defs[label])
+  end
+end
+
+function M.rebuild_refs()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+  local defs = {}
+  local def_order = {}
+  local def_seen = {}
+  local body = {}
+
+  for _, line in ipairs(lines) do
+    local label, url = line:match("^%[([^%]]+)%]:%s+(%S+)%s*$")
+    if label and url then
+      push_unique(def_order, def_seen, label)
+      defs[label] = defs[label] or url
+    else
+      table.insert(body, line)
+    end
+  end
+
+  text.trim_trailing_blank_lines(body)
+
+  local usage_order = labels_in_body(body, defs)
+  local usage_seen = {}
+  for _, label in ipairs(usage_order) do
+    usage_seen[label] = true
+  end
+
+  for _, label in ipairs(def_order) do
+    if defs[label] and not usage_seen[label] then
+      table.insert(usage_order, label)
+      usage_seen[label] = true
+    end
+  end
+
+  M.append_definitions(body, defs, usage_order)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, body)
+end
+
+return M

--- a/config/nvim/lua/weeknotes/text.lua
+++ b/config/nvim/lua/weeknotes/text.lua
@@ -1,0 +1,112 @@
+local M = {}
+
+function M.trim(value)
+  return (value:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+function M.normalize_ascii_quotes(value)
+  local normalized = value
+    :gsub("“", '"')
+    :gsub("”", '"')
+    :gsub("„", '"')
+    :gsub("‟", '"')
+    :gsub("‘", "'")
+    :gsub("’", "'")
+    :gsub("‚", "'")
+    :gsub("‛", "'")
+
+  return normalized
+end
+
+function M.normalize_paste_artifacts(value)
+  return value
+    :gsub("\226\128\168", " ") -- U+2028 LINE SEPARATOR
+    :gsub("\226\128\169", " ") -- U+2029 PARAGRAPH SEPARATOR
+    :gsub("\194\160", " ") -- U+00A0 NO-BREAK SPACE
+    :gsub("\226\128\139", "") -- U+200B ZERO WIDTH SPACE
+    :gsub("\226\128\140", "") -- U+200C ZERO WIDTH NON-JOINER
+    :gsub("\226\128\141", "") -- U+200D ZERO WIDTH JOINER
+end
+
+function M.is_url(value)
+  return value:match("^https?://%S+$") ~= nil
+end
+
+function M.strip_outer_quotes(value)
+  local trimmed = M.trim(value)
+  if #trimmed < 2 then
+    return trimmed
+  end
+
+  local first = trimmed:sub(1, 1)
+  local last = trimmed:sub(-1)
+  local is_double = first == '"' and last == '"'
+  local is_single = first == "'" and last == "'"
+
+  if is_double or is_single then
+    return M.trim(trimmed:sub(2, -2))
+  end
+
+  return trimmed
+end
+
+function M.wrap_text(text, max_width)
+  local words = {}
+  for word in text:gmatch("%S+") do
+    table.insert(words, word)
+  end
+
+  if #words == 0 then
+    return { "" }
+  end
+
+  local wrapped = {}
+  local current = ""
+
+  for _, word in ipairs(words) do
+    local candidate = current == "" and word or (current .. " " .. word)
+    if #candidate <= max_width or current == "" then
+      current = candidate
+    else
+      table.insert(wrapped, current)
+      current = word
+    end
+  end
+
+  if current ~= "" then
+    table.insert(wrapped, current)
+  end
+
+  return wrapped
+end
+
+function M.append_wrapped_block(output, first_prefix, next_prefix, text, wrap_width)
+  local first_width = math.max(20, wrap_width - #first_prefix)
+  local next_width = math.max(20, wrap_width - #next_prefix)
+  local wrapped = M.wrap_text(text, first_width)
+
+  if #wrapped > 0 then
+    table.insert(output, first_prefix .. wrapped[1])
+  end
+
+  for index = 2, #wrapped do
+    local continuation_lines = M.wrap_text(wrapped[index], next_width)
+    for _, continuation in ipairs(continuation_lines) do
+      table.insert(output, next_prefix .. continuation)
+    end
+  end
+end
+
+function M.trim_trailing_blank_lines(lines)
+  while #lines > 0 and lines[#lines] == "" do
+    table.remove(lines)
+  end
+end
+
+function M.sort_labels(labels)
+  table.sort(labels, function(a, b)
+    return a:lower() < b:lower()
+  end)
+end
+
+return M

--- a/config/nvim/lua/weeknotes/transform.lua
+++ b/config/nvim/lua/weeknotes/transform.lua
@@ -1,0 +1,212 @@
+local refs = require("weeknotes.refs")
+local text = require("weeknotes.text")
+
+local M = {}
+
+local function is_top_level_bullet(line)
+  return line:match("^%-%s+") ~= nil
+end
+
+local function is_bullet_block_line(line)
+  return line:match("^%-%s+") ~= nil or line:match("^%s") ~= nil or line == ""
+end
+
+local function is_outer_quoted(value)
+  if #value < 2 then
+    return false
+  end
+
+  local first = value:sub(1, 1)
+  local last = value:sub(-1)
+  return (first == '"' and last == '"') or (first == "'" and last == "'")
+end
+
+local function parse_child_entry(raw_child)
+  local normalized = text.normalize_ascii_quotes(raw_child)
+  local trimmed = text.trim(normalized)
+
+  if trimmed == "" then
+    return nil
+  end
+
+  if text.is_url(trimmed) then
+    return { kind = "url", text = trimmed }
+  end
+
+  if trimmed:match("^>%s*") then
+    return {
+      kind = "text",
+      quoted = true,
+      text = text.trim(trimmed:gsub("^>%s*", "")),
+    }
+  end
+
+  if is_outer_quoted(trimmed) then
+    return {
+      kind = "text",
+      quoted = true,
+      text = text.strip_outer_quotes(trimmed),
+    }
+  end
+
+  return {
+    kind = "text",
+    quoted = false,
+    text = trimmed,
+  }
+end
+
+local function inline_labels_in_order(value)
+  local labels = {}
+  for label in value:gmatch("%[([^%]]+)%]") do
+    table.insert(labels, label)
+  end
+
+  return labels
+end
+
+local function parse_items(lines)
+  local items = {}
+  local current = nil
+
+  for _, raw in ipairs(lines) do
+    local line = text.normalize_paste_artifacts(raw):gsub("\t", "  ")
+    local indent, bullet_text = line:match("^(%s*)%-%s+(.*)$")
+
+    if bullet_text then
+      if #indent == 0 then
+        if current then
+          table.insert(items, current)
+        end
+
+        current = {
+          text = text.trim(bullet_text),
+          children = {},
+        }
+      elseif current then
+        table.insert(current.children, text.trim(bullet_text))
+      end
+    elseif current then
+      local continuation = text.trim(line)
+      if continuation ~= "" then
+        if #current.children > 0 then
+          current.children[#current.children] = current.children[#current.children] .. " " .. continuation
+        else
+          current.text = current.text .. " " .. continuation
+        end
+      end
+    end
+  end
+
+  if current then
+    table.insert(items, current)
+  end
+
+  return items
+end
+
+local function build_lines(items, wrap_width)
+  local output = {}
+  local ref_defs = {}
+  local ref_order = {}
+  local ref_seen = {}
+  local child_indent = "  "
+  local quote_prefix = child_indent .. "> "
+
+  for index, item in ipairs(items) do
+    local item_text = text.normalize_ascii_quotes(item.text)
+    local child_entries = {}
+    local child_urls = {}
+
+    for _, child in ipairs(item.children) do
+      local entry = parse_child_entry(child)
+      if entry and entry.kind == "url" then
+        table.insert(child_urls, entry.text)
+      elseif entry and entry.kind == "text" then
+        table.insert(child_entries, entry)
+      end
+    end
+
+    local inline_labels = inline_labels_in_order(item_text)
+    local has_inline_labels = #inline_labels > 0
+
+    if has_inline_labels and #child_urls > 0 then
+      text.append_wrapped_block(output, "- ", child_indent, item_text, wrap_width)
+
+      local map_count = math.min(#inline_labels, #child_urls)
+      for i = 1, map_count do
+        local label = inline_labels[i]
+        local mapped_url = child_urls[i]
+        ref_defs[label] = ref_defs[label] or mapped_url
+        if not ref_seen[label] then
+          ref_seen[label] = true
+          table.insert(ref_order, label)
+        end
+      end
+    elseif child_urls[1] then
+      ref_defs[item_text] = ref_defs[item_text] or child_urls[1]
+      if not ref_seen[item_text] then
+        ref_seen[item_text] = true
+        table.insert(ref_order, item_text)
+      end
+      table.insert(output, "- [" .. item_text .. "]")
+    else
+      text.append_wrapped_block(output, "- ", child_indent, item_text, wrap_width)
+    end
+
+    if #child_entries > 0 then
+      table.insert(output, "")
+      for child_index, entry in ipairs(child_entries) do
+        local prefix = entry.quoted and quote_prefix or child_indent
+        text.append_wrapped_block(output, prefix, prefix, entry.text, wrap_width)
+
+        if child_index < #child_entries then
+          table.insert(output, "")
+        end
+      end
+    end
+
+    if index < #items then
+      table.insert(output, "")
+    end
+  end
+
+  text.trim_trailing_blank_lines(output)
+  refs.append_definitions(output, ref_defs, ref_order)
+
+  return output
+end
+
+function M.transform_range(line_start, line_end)
+  local bufnr = vim.api.nvim_get_current_buf()
+  local textwidth = vim.bo[bufnr].textwidth
+  local wrap_width = textwidth > 0 and textwidth or 80
+  local input_lines = vim.api.nvim_buf_get_lines(bufnr, line_start - 1, line_end, false)
+  local output_lines = {}
+  local index = 1
+
+  while index <= #input_lines do
+    local line = input_lines[index]
+
+    if is_top_level_bullet(line) then
+      local block = {}
+      while index <= #input_lines and is_bullet_block_line(input_lines[index]) do
+        table.insert(block, input_lines[index])
+        index = index + 1
+      end
+
+      local transformed = build_lines(parse_items(block), wrap_width)
+      for _, transformed_line in ipairs(transformed) do
+        table.insert(output_lines, transformed_line)
+      end
+    else
+      table.insert(output_lines, line)
+      index = index + 1
+    end
+  end
+
+  vim.api.nvim_buf_set_lines(bufnr, line_start - 1, line_end, false, output_lines)
+  refs.rebuild_refs()
+end
+
+return M

--- a/config/nvim/plugin/weeknotes.lua
+++ b/config/nvim/plugin/weeknotes.lua
@@ -1,0 +1,5 @@
+local weeknotes = require("weeknotes")
+
+vim.api.nvim_create_user_command("WeeknotesTransform", function(opts)
+  weeknotes.transform_range(opts.line1, opts.line2)
+end, { range = true, desc = "Transform pasted notes bullets into weeknotes markdown" })

--- a/config/nvim/tests/minimal_init.lua
+++ b/config/nvim/tests/minimal_init.lua
@@ -1,0 +1,7 @@
+local config_root = vim.fn.expand("~/.config/nvim")
+local data_root = vim.fn.stdpath("data")
+
+vim.opt.runtimepath:prepend(config_root)
+vim.opt.runtimepath:prepend(data_root .. "/lazy/plenary.nvim")
+
+vim.cmd("filetype plugin indent on")

--- a/config/nvim/tests/weeknotes/expected/sample-canonical.expected.md
+++ b/config/nvim/tests/weeknotes/expected/sample-canonical.expected.md
@@ -1,0 +1,18 @@
+- [Lorem Portal]
+
+  > Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+  > tempor incididunt ut labore et dolore magna aliqua.
+
+- [Dolor Digest]
+
+  Weekly roundup of sit amet links and tiny notes.
+
+- I think "context drift" is now part of every engineering conversation this
+  year.
+
+- Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+  incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis
+  nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+[Lorem Portal]: https://example.com/lorem-portal
+[Dolor Digest]: https://example.com/dolor-digest

--- a/config/nvim/tests/weeknotes/expected/sample-frontmatter.expected.md
+++ b/config/nvim/tests/weeknotes/expected/sample-frontmatter.expected.md
@@ -1,0 +1,17 @@
+---
+date: "2026-03-01"
+title: Weeknotes 244
+subtitle:
+---
+
+- [Lorem Candidate]
+
+  Excited to try lorem ipsum!
+
+- [Ipsum Arbor]
+
+  > A lorem tree with line counts
+
+[Lorem Candidate]: https://example.com/lorem-candidate
+[Ipsum Arbor]: https://example.com/ipsum-arbor
+[Existing Lorem Ref]: https://example.com/existing-lorem

--- a/config/nvim/tests/weeknotes/expected/sample-inline-label-mapping.expected.md
+++ b/config/nvim/tests/weeknotes/expected/sample-inline-label-mapping.expected.md
@@ -1,0 +1,9 @@
+- An item [lorem] and [ipsum]
+
+  This is some lorem commentary
+
+- Another [dolor] thing
+
+[lorem]: https://example.com/lorem
+[ipsum]: https://example.com/ipsum
+[dolor]: https://example.com/dolor

--- a/config/nvim/tests/weeknotes/expected/sample-paste-artifacts.expected.md
+++ b/config/nvim/tests/weeknotes/expected/sample-paste-artifacts.expected.md
@@ -1,0 +1,5 @@
+- [Lorem separator]
+
+  Lorem ipsum 2026 after all. Still here.
+
+[Lorem separator]: https://example.com/lorem-separator

--- a/config/nvim/tests/weeknotes/expected/sample-plain-wrap.expected.md
+++ b/config/nvim/tests/weeknotes/expected/sample-plain-wrap.expected.md
@@ -1,0 +1,3 @@
+- Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+  incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis
+  nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/config/nvim/tests/weeknotes/expected/sample-quotes.expected.md
+++ b/config/nvim/tests/weeknotes/expected/sample-quotes.expected.md
@@ -1,0 +1,6 @@
+- [Quoted Ipsum]
+
+  > Lorem ipsum dolor sit amet, they said "inner quote", consectetur adipiscing
+  > elit.
+
+[Quoted Ipsum]: https://example.com/quoted-ipsum/

--- a/config/nvim/tests/weeknotes/expected/sample-refs-first-appearance.expected.md
+++ b/config/nvim/tests/weeknotes/expected/sample-refs-first-appearance.expected.md
@@ -1,0 +1,5 @@
+- [Gamma Ipsum]
+- [Alpha Lorem]
+
+[Gamma Ipsum]: https://example.com/gamma
+[Alpha Lorem]: https://example.com/alpha

--- a/config/nvim/tests/weeknotes/expected/sample-refs.expected.md
+++ b/config/nvim/tests/weeknotes/expected/sample-refs.expected.md
@@ -1,0 +1,5 @@
+- [Gamma Ipsum]
+- [Alpha Lorem]
+
+[Gamma Ipsum]: https://example.com/gamma
+[Alpha Lorem]: https://example.com/alpha

--- a/config/nvim/tests/weeknotes/fixtures/sample-canonical.input.txt
+++ b/config/nvim/tests/weeknotes/fixtures/sample-canonical.input.txt
@@ -1,0 +1,11 @@
+- Lorem Portal
+    - “Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.”
+    - https://example.com/lorem-portal
+
+- Dolor Digest
+    - Weekly roundup of sit amet links and tiny notes.
+    - https://example.com/dolor-digest
+
+- I think “context drift” is now part of every engineering conversation this year.
+
+- Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/config/nvim/tests/weeknotes/fixtures/sample-frontmatter.input.md
+++ b/config/nvim/tests/weeknotes/fixtures/sample-frontmatter.input.md
@@ -1,0 +1,15 @@
+---
+date: "2026-03-01"
+title: Weeknotes 244
+subtitle:
+---
+
+- Lorem Candidate
+    - Excited to try lorem ipsum!
+    - https://example.com/lorem-candidate
+
+- Ipsum Arbor
+    - "A lorem tree with line counts"
+    - https://example.com/ipsum-arbor
+
+[Existing Lorem Ref]: https://example.com/existing-lorem

--- a/config/nvim/tests/weeknotes/fixtures/sample-inline-label-mapping.input.txt
+++ b/config/nvim/tests/weeknotes/fixtures/sample-inline-label-mapping.input.txt
@@ -1,0 +1,7 @@
+- An item [lorem] and [ipsum]
+    - This is some lorem commentary
+    - https://example.com/lorem
+    - https://example.com/ipsum
+
+- Another [dolor] thing
+    - https://example.com/dolor

--- a/config/nvim/tests/weeknotes/fixtures/sample-paste-artifacts.input.txt
+++ b/config/nvim/tests/weeknotes/fixtures/sample-paste-artifacts.input.txt
@@ -1,0 +1,3 @@
+- Lorem separator
+    - Lorem ipsum 2026 after all. Still here.
+    - https://example.com/lorem-separator

--- a/config/nvim/tests/weeknotes/fixtures/sample-plain-wrap.input.txt
+++ b/config/nvim/tests/weeknotes/fixtures/sample-plain-wrap.input.txt
@@ -1,0 +1,1 @@
+- Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/config/nvim/tests/weeknotes/fixtures/sample-quotes.input.txt
+++ b/config/nvim/tests/weeknotes/fixtures/sample-quotes.input.txt
@@ -1,0 +1,3 @@
+- Quoted Ipsum
+    - “Lorem ipsum dolor sit amet, they said “inner quote”, consectetur adipiscing elit.”
+    - https://example.com/quoted-ipsum/

--- a/config/nvim/tests/weeknotes/fixtures/sample-refs.input.md
+++ b/config/nvim/tests/weeknotes/fixtures/sample-refs.input.md
@@ -1,0 +1,6 @@
+- [Gamma Ipsum]
+- [Alpha Lorem]
+
+[Gamma Ipsum]: https://example.com/gamma
+[Alpha Lorem]: https://example.com/alpha
+[Gamma Ipsum]: https://example.com/gamma-ignored

--- a/config/nvim/tests/weeknotes/weeknotes_spec.lua
+++ b/config/nvim/tests/weeknotes/weeknotes_spec.lua
@@ -1,0 +1,145 @@
+-- Run this spec with:
+-- nvim --headless "+PlenaryBustedDirectory ~/.config/nvim/tests/weeknotes { minimal_init = '~/.config/nvim/tests/minimal_init.lua' }" +qa
+
+local weeknotes = require("weeknotes")
+
+local function fixture_path(name)
+  return vim.fn.expand("~/.config/nvim/tests/weeknotes/fixtures/" .. name)
+end
+
+local function expected_path(name)
+  return vim.fn.expand("~/.config/nvim/tests/weeknotes/expected/" .. name)
+end
+
+local function read_lines(path)
+  return vim.fn.readfile(path)
+end
+
+local function with_buffer(lines, fn)
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(bufnr)
+  vim.bo[bufnr].textwidth = 80
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  fn(bufnr)
+  return vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+end
+
+describe("weeknotes", function()
+  it("transforms canonical notes content", function()
+    local input = read_lines(fixture_path("sample-canonical.input.txt"))
+    local expected = read_lines(expected_path("sample-canonical.expected.md"))
+
+    local actual = with_buffer(input, function(bufnr)
+      weeknotes.transform_range(1, vim.api.nvim_buf_line_count(bufnr))
+    end)
+
+    assert.are.same(expected, actual)
+  end)
+
+  it("wraps plain top-level bullets with markdown continuation indent", function()
+    local input = read_lines(fixture_path("sample-plain-wrap.input.txt"))
+    local expected = read_lines(expected_path("sample-plain-wrap.expected.md"))
+
+    local actual = with_buffer(input, function(bufnr)
+      weeknotes.transform_range(1, vim.api.nvim_buf_line_count(bufnr))
+    end)
+
+    assert.are.same(expected, actual)
+  end)
+
+  it("normalizes smart quotes and strips only outer child quotes", function()
+    local input = read_lines(fixture_path("sample-quotes.input.txt"))
+    local expected = read_lines(expected_path("sample-quotes.expected.md"))
+
+    local actual = with_buffer(input, function(bufnr)
+      weeknotes.transform_range(1, vim.api.nvim_buf_line_count(bufnr))
+    end)
+
+    assert.are.same(expected, actual)
+  end)
+
+  it("rebuilds references with stable dedupe behavior", function()
+    local input = read_lines(fixture_path("sample-refs.input.md"))
+    local expected = read_lines(expected_path("sample-refs.expected.md"))
+
+    local actual = with_buffer(input, function()
+      weeknotes.rebuild_refs()
+    end)
+
+    assert.are.same(expected, actual)
+  end)
+
+  it("rebuilds references in first-appearance order", function()
+    local input = read_lines(fixture_path("sample-refs.input.md"))
+    local expected = read_lines(expected_path("sample-refs-first-appearance.expected.md"))
+
+    local actual = with_buffer(input, function()
+      weeknotes.rebuild_refs()
+    end)
+
+    assert.are.same(expected, actual)
+  end)
+
+  it("preserves non-bullet lines and only transforms bullet blocks", function()
+    local input = read_lines(fixture_path("sample-frontmatter.input.md"))
+    local expected = read_lines(expected_path("sample-frontmatter.expected.md"))
+
+    local actual = with_buffer(input, function(bufnr)
+      weeknotes.transform_range(1, vim.api.nvim_buf_line_count(bufnr))
+    end)
+
+    assert.are.same(expected, actual)
+  end)
+
+  it("maps inline labels to child URLs in order", function()
+    local input = read_lines(fixture_path("sample-inline-label-mapping.input.txt"))
+    local expected = read_lines(expected_path("sample-inline-label-mapping.expected.md"))
+
+    local actual = with_buffer(input, function(bufnr)
+      weeknotes.transform_range(1, vim.api.nvim_buf_line_count(bufnr))
+    end)
+
+    assert.are.same(expected, actual)
+  end)
+
+  it("rebuilds refs at document bottom after partial range transform", function()
+    local input = {
+      "Header line",
+      "",
+      "- Item [foo]",
+      "    - https://foo.com",
+      "",
+      "Tail line",
+      "",
+      "[tail]: https://tail.com",
+    }
+
+    local expected = {
+      "Header line",
+      "",
+      "- Item [foo]",
+      "",
+      "Tail line",
+      "",
+      "[foo]: https://foo.com",
+      "[tail]: https://tail.com",
+    }
+
+    local actual = with_buffer(input, function()
+      weeknotes.transform_range(3, 5)
+    end)
+
+    assert.are.same(expected, actual)
+  end)
+
+  it("normalizes paste artifact unicode separators", function()
+    local input = read_lines(fixture_path("sample-paste-artifacts.input.txt"))
+    local expected = read_lines(expected_path("sample-paste-artifacts.expected.md"))
+
+    local actual = with_buffer(input, function(bufnr)
+      weeknotes.transform_range(1, vim.api.nvim_buf_line_count(bufnr))
+    end)
+
+    assert.are.same(expected, actual)
+  end)
+end)


### PR DESCRIPTION
Adds a `:WeeknotesTransform` command to help with weeknote authoring.

- Sanitises weirdo characters coming from Apple Notes
- Auto-links Markdown style reference links
- Wraps text to my whims
- Correctly indents quoted blocks etc